### PR TITLE
#pr Adicionado mapflag para bloqueio de armazém nos mapas.

### DIFF
--- a/db/const.txt
+++ b/db/const.txt
@@ -247,6 +247,8 @@ mf_allowks	48
 mf_monster_noteleport	49
 mf_pvp_nocalcrank	50
 mf_battleground	51
+mf_reset	52
+mf_nostorage	53
 
 cell_walkable	0
 cell_shootable	1

--- a/docs/mf_nostorage.txt
+++ b/docs/mf_nostorage.txt
@@ -1,0 +1,28 @@
+---------------------------------------
+*mf_nostorage
+
+Permite bloquear a abertura de storage para jogadores no mapa em que for definida.
+Existem 3 configurações possíveis para esta mapflag.
+
+1ª Configuração:
+```
+	// Bloqueia a abertura de storage por comando @storage
+	// As kafras conseguem abrir storage do player.
+	prontera	mapflag	nostorage	1
+```
+
+2ª Configuração:
+```
+	// Bloqueia a abertura de storage por comando de npc.
+	// As kafras não conseguem abrir storage do player.
+	// O Jogador consegue usar o @storage
+	prontera	mapflag	nostorage	2
+```
+
+3ª Configuração:
+```
+	// Bloqueia a abertura de storage
+	// As kafras não conseguem abrir storage do player.
+	// O Jogador não consegue usar o @storage
+	prontera	mapflag	nostorage	3
+```

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -1153,6 +1153,14 @@ ACMD_FUNC(storage)
 	if (sd->npc_id || sd->state.vending || sd->state.buyingstore || sd->state.trading || sd->state.storage_flag)
 		return -1;
 
+	// O Mapa possui restrição para abrir o armazém?
+	// A Trava 0x1 é uma trava de comando, impede de abrir por @storage.
+	// [CarlosHenrq, 2020-07-21]
+	if ((map[sd->bl.m].flag.nostorage & 0x1)) {
+		clif_displaymessage(sd->fd, msg_txt(527));
+		return -1;
+	}
+
 	if (storage_storageopen(sd) == 1)
 	{	//Already open.
 		clif_displaymessage(fd, msg_txt(250));

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -492,6 +492,7 @@ struct map_data {
 		unsigned guildlock :1;
 		unsigned src4instance : 1; // To flag this map when it's used as a src map for instances
 		unsigned reset :1; // [Daegaladh]
+		unsigned nostorage : 2; // [CarlosHenrq, 2020-07-21]
 	} flag;
 	struct point save;
 	struct npc_data *npc[MAX_NPC_PER_MAP];

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -3112,6 +3112,8 @@ static const char* npc_parse_mapflag(char* w1, char* w2, char* w3, char* w4, con
 		map[m].flag.guildlock=state;
 	else if (!strcmpi(w3,"reset"))
 		map[m].flag.reset=state;
+    else if (!strcmpi(w3, "nostorage"))
+        map[m].flag.nostorage = state;
 	else
 		ShowError("npc_parse_mapflag: mapflag nao reconhecido '%s' (arquivo '%s', linha '%d').\n", w3, filepath, strline(buffer,start-buffer));
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -357,7 +357,8 @@ enum {
 	MF_MONSTER_NOTELEPORT,
 	MF_PVP_NOCALCRANK,	//50
 	MF_BATTLEGROUND,
-	MF_RESET
+	MF_RESET,
+    MF_NOSTORAGE
 };
 
 const char* script_op2name(int op)
@@ -9633,6 +9634,7 @@ BUILDIN_FUNC(getmapflag)
 			case MF_PVP_NOCALCRANK:		script_pushint(st,map[m].flag.pvp_nocalcrank); break;
 			case MF_BATTLEGROUND:		script_pushint(st,map[m].flag.battleground); break;
 			case MF_RESET:			script_pushint(st,map[m].flag.reset); break;
+            case MF_NOSTORAGE:          script_pushint(st, map[m].flag.nostorage); break;
 		}
 	}
 
@@ -9703,6 +9705,7 @@ BUILDIN_FUNC(setmapflag)
 			case MF_PVP_NOCALCRANK:		map[m].flag.pvp_nocalcrank=1; break;
 			case MF_BATTLEGROUND:		map[m].flag.battleground = (!val || atoi(val) < 0 || atoi(val) > 2) ? 1 : atoi(val); break;
 			case MF_RESET:			map[m].flag.reset=1; break;
+            case MF_NOSTORAGE:          map[m].flag.nostorage = cap_value(atoi(val), 1, 3); break;
 		}
 	}
 
@@ -9770,6 +9773,7 @@ BUILDIN_FUNC(removemapflag)
 			case MF_PVP_NOCALCRANK:		map[m].flag.pvp_nocalcrank=0; break;
 			case MF_BATTLEGROUND:		map[m].flag.battleground=0; break;
 			case MF_RESET:				map[m].flag.reset=0; break;
+            case MF_NOSTORAGE:          map[m].flag.nostorage = 0; break;
 		}
 	}
 
@@ -14861,7 +14865,7 @@ BUILDIN_FUNC(pushpc)
 
 /*================================================================
  * sc_check(<sc_type>) - [Floozie & MidNight]
- * Verifica se o jogador est· sobre efeito do status especificado.
+ * Verifica se o jogador estÅEsobre efeito do status especificado.
  *---------------------------------------------------------------*/
 
 BUILDIN_FUNC(sc_check)

--- a/src/map/storage.c
+++ b/src/map/storage.c
@@ -101,6 +101,14 @@ int storage_storageopen(struct map_session_data *sd)
 		return 1;
 	}
 
+	// O Mapa possui restrição para abrir o armazém?
+	// A Trava 0x2 é uma trava global, impede de abrir até por kafra.
+	// [CarlosHenrq, 2020-07-21]
+	if ((map[sd->bl.m].flag.nostorage & 0x2)) {
+		clif_displaymessage(sd->fd, msg_txt(527));
+		return 1;
+	}
+
 	sd->state.storage_flag = 1;
 	storage_sortitem(sd->status.storage.items, ARRAYLENGTH(sd->status.storage.items));
 	clif_storagelist(sd, sd->status.storage.items, ARRAYLENGTH(sd->status.storage.items));


### PR DESCRIPTION
*mf_nostorage

Permite bloquear a abertura de storage para jogadores no mapa em que for definida.
Existem 3 configurações possíveis para esta mapflag.

1ª Configuração:
```
	// Bloqueia a abertura de storage por comando @storage
	// As kafras conseguem abrir storage do player.
	prontera	mapflag	nostorage	1
```

2ª Configuração:
```
	// Bloqueia a abertura de storage por comando de npc.
	// As kafras não conseguem abrir storage do player.
	// O Jogador consegue usar o @storage
	prontera	mapflag	nostorage	2
```

3ª Configuração:
```
	// Bloqueia a abertura de storage
	// As kafras não conseguem abrir storage do player.
	// O Jogador não consegue usar o @storage
	prontera	mapflag	nostorage	3
```